### PR TITLE
Tests that when loading a relationship exception is not thrown.

### DIFF
--- a/src/SellerLabs/Beakers/Traits/ModelTestTrait.php
+++ b/src/SellerLabs/Beakers/Traits/ModelTestTrait.php
@@ -11,6 +11,7 @@
 
 namespace SellerLabs\Beakers\Traits;
 
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -173,6 +174,33 @@ trait ModelTestTrait
                 break;
             case RelationType::BELONGS_TO_MANY:
                 $this->assertBelongsToMany($model, $property, $other);
+                break;
+        }
+    }
+
+
+    /**
+     * Tests relationship are connected to correct tables through correct keys.
+     *
+     * @param string $property
+     * @param string $type
+     * @param string $other
+     *
+     * @dataProvider relationsProvider
+     */
+    public function testRelationCanLoad($property, $type, $other)
+    {
+        $model = $this->make();
+
+        switch ($type) {
+            case RelationType::HAS_ONE:
+            case RelationType::BELONGS_TO:
+                $this->assertTrue(is_null($model->$property));
+                break;
+            case RelationType::HAS_MANY:
+            case RelationType::HAS_MANY_THROUGH:
+            case RelationType::BELONGS_TO_MANY:
+                $this->assertTrue($model->$property instanceof Collection);
                 break;
         }
     }


### PR DESCRIPTION
There are cases where the type of relationships are properly but we didn't test if the database resolves them properly. This catches issues like such

```
1) Tests\SellerLabs\Snagshout\Products\ProductTest::testRelationCanLoad with data set #1 ('campaigns', 'belongsToMany', 'SellerLabs\Snagshout\Campaign...mpaign')
Illuminate\Database\QueryException: SQLSTATE[HY000]: General error: 1 no such table: campaign_product (SQL: select "campaigns".*, "campaign_product"."product_id" as "pivot_product_id", "campaign_product"."campaign_id" as "pivot_campaign_id" from "campaigns" inner join "campaign_product" on "campaigns"."id" = "campaign_product"."campaign_id" where "campaigns"."deleted_at" is null and "campaign_product"."product_id" is null)
```