### PR TITLE
Mark vaughn patch 1

### DIFF
--- a/src/SellerLabs/Beakers/Traits/ModelTestTrait.php
+++ b/src/SellerLabs/Beakers/Traits/ModelTestTrait.php
@@ -13,6 +13,7 @@ namespace SellerLabs\Beakers\Traits;
 
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\RelationNotFoundException;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -129,7 +130,6 @@ trait ModelTestTrait
         $property,
         $other
     ) {
-
         $this->assertTrue(method_exists($model, $property));
 
         /** @var HasManyThrough $relation */
@@ -147,6 +147,16 @@ trait ModelTestTrait
     abstract public function relationsProvider();
 
     /**
+     * Checks if all relations are covered.
+     */
+    public function testAllRelationsCovered()
+    {
+        $relations = $this->relationsProvider();
+        $model = $this->make()->getRelations();
+        $this->assertEquals(count($model) ,count($relations));
+    }
+
+    /**
      * Tests relationship definitions.
      *
      * @param string $property
@@ -158,6 +168,10 @@ trait ModelTestTrait
     public function testRelations($property, $type, $other)
     {
         $model = $this->make();
+
+        if(!in_array($property, $model->getRelations())){
+            throw RelationNotFoundException::make($this->class, $property);
+        }
 
         switch ($type) {
             case RelationType::HAS_ONE:

--- a/src/SellerLabs/Beakers/Traits/ModelTestTrait.php
+++ b/src/SellerLabs/Beakers/Traits/ModelTestTrait.php
@@ -13,7 +13,6 @@ namespace SellerLabs\Beakers\Traits;
 
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\RelationNotFoundException;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -153,7 +152,7 @@ trait ModelTestTrait
     {
         $relations = $this->relationsProvider();
         $model = $this->make()->getRelations();
-        $this->assertEquals(count($model) ,count($relations));
+        $this->assertEquals(count($model), count($relations));
     }
 
     /**
@@ -169,9 +168,11 @@ trait ModelTestTrait
     {
         $model = $this->make();
 
-        if(!in_array($property, $model->getRelations())){
-            throw RelationNotFoundException::make($this->class, $property);
-        }
+        $this->assertContains(
+            $property,
+            $model->getRelations(),
+            "[{$property}] not defined in [" . $this->className . ']'
+        );
 
         switch ($type) {
             case RelationType::HAS_ONE:
@@ -191,7 +192,6 @@ trait ModelTestTrait
                 break;
         }
     }
-
 
     /**
      * Tests relationship are connected to correct tables through correct keys.


### PR DESCRIPTION
This makes model tests more strict, checking that they are defined in $relations
Adds new `testAllRelationsCovered` test and adds a check that a tested property is in the model relations